### PR TITLE
Fix path for image ArgBoum.gif

### DIFF
--- a/exports/autoGames/tictac.js
+++ b/exports/autoGames/tictac.js
@@ -19,7 +19,7 @@ const boomTable = [
   "exports/autoGames/images/BOOM02.gif",
   "exports/autoGames/images/boomPump.gif",
   "exports/autoGames/images/dalekBoom.gif",
-  "exports/autoGames/images/ArgBoom.gif"
+  "exports/autoGames/images/ArgBoum.gif"
 ]
 
 module.exports = {


### PR DESCRIPTION
Le jeux tic-tac-boom référençais un gif avec une erreur dans le chemin.

Cependant le gif est un explosion atomique, et il y a eu un refus (8 nov 2021, blueprint) pour l'ajout d'un autre gif similaire. Peut-être serait-il mieux de le supprimer que de corriger le path.